### PR TITLE
Fixes: Assembly name and NuGet package

### DIFF
--- a/NativeUI.csproj
+++ b/NativeUI.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NativeUI</RootNamespace>
-    <AssemblyName>NativeUI</AssemblyName>
+    <AssemblyName>NativeUI.net</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />

--- a/NativeUI.csproj
+++ b/NativeUI.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CitizenFX.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\..\..\Program Files\FiveM\FiveM.app\citizen\clr2\lib\mono\4.5\CitizenFX.Core.dll</HintPath>
+      <HintPath>packages\CitizenFX.Core.1.3.0\lib\net45\CitizenFX.Core.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="Microsoft.CSharp" />
@@ -68,7 +68,9 @@
     <Compile Include="StringMeasurer.cs" />
     <Compile Include="UIMenu.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>


### PR DESCRIPTION
This PR adds 2 fixes specific to the FiveM/CitizenFX fork:

* The output DLL now ends in `.net`, making it work on FiveM without additional changes
* The NuGet package is now installed on the correct location, avoiding the use of ugly modifications like #7 
  * Now is a good time to update the `CitizenFX.Core` package on NuGet
